### PR TITLE
Bump compat for Catlab to v0.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Petri"
 uuid = "4259d249-1051-49fa-8328-3f8ab9391c33"
 authors = ["Micah Halter <micah.halter@gtri.gatech.edu>", "James Fairbanks <james.fairbanks@gtri.gatech.edu>"]
-version = "1.2.6"
+version = "1.2.7"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
@@ -15,7 +15,7 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 
 [compat]
 AutoHashEquals = "^0.2.0"
-Catlab = "0.7.4,0.8,0.9,0.10,0.11,0.12"
+Catlab = "0.7.4,0.8,0.9,0.10,0.11,0.12,0.13"
 DiffEqBase = "^6"
 DiffEqJump = "^6"
 OrdinaryDiffEq = "^5"


### PR DESCRIPTION
This PR adds compatibility to Catlab v0.13. This shouldn't introduce any breaking changes to the Petri.jl environment and will allow for use of struct ACSet tooling alongside Petri.jl